### PR TITLE
Use constant instead of hard-coded value for avx exponent bias.

### DIFF
--- a/tests.cpp
+++ b/tests.cpp
@@ -340,6 +340,43 @@ TEST(prod_dist2_complexrealvec, odd_N) {
   delete[] x;
 }
 
+TEST(prod_dist2_complexcomplexvec, small) {
+  std::mt19937_64 gen = std::mt19937_64();
+
+  const long int M = 1000;
+
+  double * x = new_double_array(M);
+  double * y = new_double_array(M);
+
+  const double b=1e-5;
+
+  init_random_positions(gen, M,-b,b,x);
+  init_random_positions(gen, M,-b,b,y);
+
+  const long int j=262;
+  const long int N=261;
+
+  const double u=x[j-1];
+  const double u0=x[j];
+  const double v=y[j-1];
+  const double v0=y[j];
+
+  LargeExponentFloat prod1(1.0);
+  LargeExponentFloat prod2(1.0);
+
+  prod_dist2_complexcomplexvec(N,0,u,u0,v,v0,x,y,prod1,prod2);
+
+  LargeExponentFloat expectedProd1(1.01701e-43, -8687);
+  prod1.normalize_exponent();
+  expectedProd1.normalize_exponent();
+
+  EXPECT_EQ(-8829, expectedProd1.exponent);
+  EXPECT_NEAR(0.56700202185894077, expectedProd1.significand, 1e-6);
+
+  delete[] x;
+  delete[] y;
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/vandermonde_det.cpp
+++ b/vandermonde_det.cpp
@@ -67,8 +67,8 @@ void prod_diff_realrealvec(
 
   // Process the skipped block
   if (skipj < lastj) {
-    vprod1.normalize_exponent1234();
-    vprod2.normalize_exponent1234();
+    vprod1.normalize_exponent1();
+    vprod2.normalize_exponent1();
 
     __m256d vj = _mm256_set1_pd(skipj);
     vj = _mm256_add_pd(vj, _mm256_set_pd(3, 2, 1, 0));
@@ -81,8 +81,8 @@ void prod_diff_realrealvec(
     }
   }
 
-  vprod1.normalize_exponent1234();
-  vprod2.normalize_exponent1234();
+  vprod1.normalize_exponent1();
+  vprod2.normalize_exponent1();
 
   // Process the remaining elements
   __m256d vn = _mm256_set1_pd(N - 1);
@@ -192,8 +192,8 @@ void prod_dist2_complexrealvec(
 
   __m256d four = _mm256_set1_pd(4);
 
-  vprod1.normalize_exponent12();
-  vprod2.normalize_exponent12();
+  vprod1.normalize_exponent1();
+  vprod2.normalize_exponent1();
 
   // Process the remaining elements
   __m256d vn = _mm256_set1_pd(N - 1);
@@ -283,8 +283,8 @@ void prod_dist2_complexcomplexvec(
 
   // Process the skipped block
   if (skipj < lastj) [[likely]] {
-    vprod1.normalize_exponent12();
-    vprod2.normalize_exponent12();
+    vprod1.normalize_exponent1();
+    vprod2.normalize_exponent1();
 
     __m256d vj = _mm256_set1_pd(skipj);
     vj = _mm256_add_pd(vj, _mm256_set_pd(3, 2, 1, 0));
@@ -298,8 +298,8 @@ void prod_dist2_complexcomplexvec(
     }
   }
 
-  vprod1.normalize_exponent12();
-  vprod2.normalize_exponent12();
+  vprod1.normalize_exponent1();
+  vprod2.normalize_exponent1();
 
   // Process the remaining elements
   __m256d vn = _mm256_set1_pd(N - 1);


### PR DESCRIPTION
Also: Unify code that calls normmalize: We only need to normalize the first product as we only use mul_mask_no_overflow, not the 1234 version.